### PR TITLE
Force Windows shutdown in mcShutdown script

### DIFF
--- a/mcShutdown.ps1
+++ b/mcShutdown.ps1
@@ -226,7 +226,14 @@ try {
     Log "[DEBUG] Skipping Windows shutdown."
   } else {
     Log "Issuing Windows shutdown in ${ShutdownDelaySeconds}s..."
-    Start-Process -FilePath shutdown.exe -ArgumentList "/s","/t",$ShutdownDelaySeconds,"/c","UPS final shutdown" -WindowStyle Hidden
+    try {
+      # Use fully qualified path and force closing apps to ensure shutdown proceeds
+      $shutdownExe = Join-Path $env:SystemRoot 'System32\\shutdown.exe'
+      Start-Process -FilePath $shutdownExe -ArgumentList "/s","/f","/t",$ShutdownDelaySeconds,"/c","UPS final shutdown" -WindowStyle Hidden -ErrorAction Stop
+    } catch {
+      Log "ERROR: Failed to invoke shutdown.exe: $($_.Exception.Message)"
+      throw
+    }
   }
 
   Log "Done."


### PR DESCRIPTION
## Summary
- ensure mcShutdown.ps1 uses the full path to shutdown.exe and forces app closure
- log failures when invoking shutdown.exe

## Testing
- `pwsh -NoProfile -Command "try { [scriptblock]::Create((Get-Content -Raw 'mcShutdown.ps1')) | Out-Null; 'Syntax OK' } catch { \$_ }"` *(fails: command not found)*
- `apt-get install -y powershell` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_6896bd9fe4fc8320afd112d5c1fcd64e