### PR TITLE
Use environment variable for RCON password in shutdown script

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,13 @@ They are used with a synology nas that sends a signal after 20s of battery power
 then winNut is running a service waiting for that
 
 then the mcShutdown file is called so shutdown the server and then the computer safely after warning the players
+
+## mcShutdown.ps1 RCON password
+
+`mcShutdown.ps1` reads the RCON password from the `RCON_PASS` environment variable. Set it before running the script:
+
+```powershell
+$env:RCON_PASS = 'your-rcon-password'
+```
+
+This sets the variable for the current PowerShell session.

--- a/mcShutdown.ps1
+++ b/mcShutdown.ps1
@@ -10,7 +10,7 @@ $ErrorActionPreference = 'Stop'
 $McrconPath   = 'C:\mcrcon\mcrcon.exe'
 $RconHost     = '127.0.0.1'
 $RconPort     = 25575
-$RconPass     = 'REDACTED'
+$RconPass     = $env:RCON_PASS
 
 $ServiceName  = 'mc_82424'   # NSSM service name
 


### PR DESCRIPTION
## Summary
- Read RCON password from `RCON_PASS` environment variable in `mcShutdown.ps1`
- Document how to set `RCON_PASS` before running the shutdown script

## Testing
- `pwsh -NoProfile -File mcShutdown.ps1 -Debug` *(fails: command not found)*
- `apt-get install -y powershell` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_6896c2a998848320a57039284cf6096b