### PR TITLE
Handle Windows shutdown exit codes

### DIFF
--- a/mcShutdown.ps1
+++ b/mcShutdown.ps1
@@ -226,7 +226,11 @@ try {
     Log "[DEBUG] Skipping Windows shutdown."
   } else {
     Log "Issuing Windows shutdown in ${ShutdownDelaySeconds}s..."
-    Start-Process -FilePath shutdown.exe -ArgumentList "/s","/t",$ShutdownDelaySeconds,"/c","UPS final shutdown" -WindowStyle Hidden
+    $proc = Start-Process -FilePath shutdown.exe -ArgumentList "/s","/t",$ShutdownDelaySeconds,"/c","UPS final shutdown" -WindowStyle Hidden -Wait -PassThru
+    if ($proc.ExitCode -ne 0) {
+      Log ("shutdown.exe exited with code {0}" -f $proc.ExitCode)
+      throw ("shutdown.exe failed with code {0}" -f $proc.ExitCode)
+    }
   }
 
   Log "Done."


### PR DESCRIPTION
## Summary
- check `shutdown.exe` exit code in `mcShutdown.ps1`

## Testing
- `pwsh -NoLogo -NoProfile -Command "Write-Host test"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6896c2b8a6c083208362617821bea99f