### PR TITLE
Add NOTIFYTYPE guard and WinNUT reload instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,13 @@ Make a task in the task scheduler to run the script daily
 *Sometimes after making the task you need to restart the computer in order for it to start working*
 
 ## Other files
+Other files support a shutdown script triggered when a UPS master signals a power outage.
 
-other files are for a shutdown script that happens when a UPS-master signals there should be a shut down due to a power outage
+They are used with a Synology NAS that sends a signal after 20 seconds of battery power.
 
-They are used with a synology nas that sends a signal after 20s of battery power
+WinNUT runs as a service waiting for that signal.
 
-then winNut is running a service waiting for that
+The `mcShutdown` script is then called to shut down the server and, after warning players, the computer itself.
 
-then the mcShutdown file is called so shutdown the server and then the computer safely after warning the players
+After editing `upsmon.conf` (for example, enabling `NOTIFYFLAG FSD SYSLOG+EXEC`), reload or restart WinNUT so the setting takes effect.
+

--- a/README.md
+++ b/README.md
@@ -38,8 +38,18 @@ Make a task in the task scheduler to run the script daily
 These files implement a shutdown sequence triggered when a UPS master signals a power outage.
 
 - A Synology NAS sends the signal after 20 seconds on battery.
-- WinNUT runs as a service waiting for the FSD notification.
+- WinNUT runs as a service waiting for the FSD notification, then calls `mcShutdown.ps1`.
 - `mcShutdown.ps1` warns players, stops the server, then shuts down the host.
 
 After editing `upsmon.conf` (for example, enabling `NOTIFYFLAG FSD SYSLOG+EXEC`), reload or restart WinNUT so the setting takes effect.
+
+## mcShutdown.ps1 RCON password
+
+`mcShutdown.ps1` reads the RCON password from the `RCON_PASS` environment variable. Set it before running the script:
+
+```powershell
+$env:RCON_PASS = 'your-rcon-password'
+```
+
+This sets the variable for the current PowerShell session.
 

--- a/README.md
+++ b/README.md
@@ -35,13 +35,11 @@ Make a task in the task scheduler to run the script daily
 *Sometimes after making the task you need to restart the computer in order for it to start working*
 
 ## Other files
-Other files support a shutdown script triggered when a UPS master signals a power outage.
+These files implement a shutdown sequence triggered when a UPS master signals a power outage.
 
-They are used with a Synology NAS that sends a signal after 20 seconds of battery power.
-
-WinNUT runs as a service waiting for that signal.
-
-The `mcShutdown` script is then called to shut down the server and, after warning players, the computer itself.
+- A Synology NAS sends the signal after 20 seconds on battery.
+- WinNUT runs as a service waiting for the FSD notification.
+- `mcShutdown.ps1` warns players, stops the server, then shuts down the host.
 
 After editing `upsmon.conf` (for example, enabling `NOTIFYFLAG FSD SYSLOG+EXEC`), reload or restart WinNUT so the setting takes effect.
 

--- a/mcShutdown.ps1
+++ b/mcShutdown.ps1
@@ -4,6 +4,8 @@
 
 param([switch]$Debug)
 
+if ($env:NOTIFYTYPE -ne 'FSD') { Log "Ignoring event $env:NOTIFYTYPE"; exit 0 }
+
 $ErrorActionPreference = 'Stop'
 
 ############## EDIT ME ##############

--- a/upsmon.conf
+++ b/upsmon.conf
@@ -7,6 +7,7 @@ NOTIFYFLAG ONLINE   SYSLOG
 NOTIFYFLAG ONBATT   SYSLOG
 NOTIFYFLAG LOWBATT  SYSLOG
 NOTIFYFLAG FSD      SYSLOG+EXEC    # ONLY this runs your script
+# Reload or restart WinNUT after editing this file to apply changes.
 
 # --- IMPORTANT: Stop WinNUT from doing its own OS shutdown on LOWBATT ---
 # WinNUT requires SHUTDOWNCMD; point it to a no-op that returns 0.


### PR DESCRIPTION
## Summary
- Guard mcShutdown.ps1 against non-FSD events and log ignored notifications
- Document need to reload WinNUT after editing upsmon.conf and add inline reminder

## Testing
- `pwsh -NoLogo -NoProfile -Command "Write-Host test"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6896c2bb7e508320a58d1d2aa41cd7d6